### PR TITLE
Stop using Vue in payment modal

### DIFF
--- a/vue_simple_pos/vue_simple_pos/page/vue_simple_pos/modal.html
+++ b/vue_simple_pos/vue_simple_pos/page/vue_simple_pos/modal.html
@@ -3,34 +3,35 @@
     <div class="pos-items image-view-container">
       
       {% if not cart %}
-      <p>{{ _("No items in cart.") }}</p>
+      <p>{{ no_items }}</p>
       {% endif %}
 
+      {% for cart_item in cart %}
       <!------- START ITEM -------->
-      {% for item_code, qty in cart.items() %}
       <div class="pos-item-wrapper image-view-item">
         <div class="image-view-header">
           <div>
             <span class="grey list-id">
-              {{ items[item_code].item_name }}
+              {{ cart_item.name }}
             </span>
             <span class="badge badge-pill bg-warning text-light">
-              {{ qty }}
+              {{ cart_item.qty }}
             </span>
           </div>
         </div>
         <div>
-          {% if items[item_code].thumbnail %}
-          <img class="img-responsive" src="{{ items[item_code].thumbnail }}"
-            alt="{{ items[item_code].item_name }}">
+          {% if cart_item.thumbnail %}
+          <img class="img-responsive" 
+            src="{{ cart_item.thumbnail }}"
+            alt="{{ cart_item.name }}">
           {% endif %}
           <span class="price-info">
-            {{ items[item_code].standard_rate }}
+            {{ cart_item.rate }}
           </span>
         </div>
       </div>
-      {% endfor %}
       <!------- END ITEM -------->
+      {% endfor %}
 
     </div>
   </div>

--- a/vue_simple_pos/vue_simple_pos/page/vue_simple_pos/modal.html
+++ b/vue_simple_pos/vue_simple_pos/page/vue_simple_pos/modal.html
@@ -1,10 +1,14 @@
 <div class="item-container">
   <div class="list-item-table pos-items-wrapper">
     <div class="pos-items image-view-container">
-      <p v-if="noItems()">{{__("No items in cart.")}}</p>
+      
+      {% if not cart %}
+      <p>{{ _("No items in cart.") }}</p>
+      {% endif %}
 
       <!------- START ITEM -------->
-      <div v-for="(qty, item_code) of cart" class="pos-item-wrapper image-view-item">
+      {% for item_code, qty in cart.items() %}
+      <div class="pos-item-wrapper image-view-item">
         <div class="image-view-header">
           <div>
             <span class="grey list-id">
@@ -16,13 +20,16 @@
           </div>
         </div>
         <div>
-          <img class="img-responsive" v-if="items[item_code].thumbnail" v-bind:src="items[item_code].thumbnail"
-            v-bind:alt="items[item_code].item_name">
+          {% if items[item_code].thumbnail %}
+          <img class="img-responsive" src="{{ items[item_code].thumbnail }}"
+            alt="{{ items[item_code].item_name }}">
+          {% endif %}
           <span class="price-info">
-            {{ formatCurrency(items[item_code].standard_rate) }}
+            {{ items[item_code].standard_rate }}
           </span>
         </div>
       </div>
+      {% endfor %}
       <!------- END ITEM -------->
 
     </div>

--- a/vue_simple_pos/vue_simple_pos/page/vue_simple_pos/vue_simple_pos.js
+++ b/vue_simple_pos/vue_simple_pos/page/vue_simple_pos/vue_simple_pos.js
@@ -287,13 +287,17 @@ class Payment {
 		this.amount = amount;
 		this.mode_of_payment = __('Cash');
 		this.events = events;
-		this.cart = cart;
-		this.items = {};
+		this.cart = [];
 
-		// Assign items and format price
-		for (var item in items) {
-			this.items[item] = items[item];
-			this.items[item].standard_rate = format_currency(items[item].standard_rate, this.currency);
+		for (let cart_item in cart) {
+			let list_el = {
+				code: cart_item,
+				qty: cart[cart_item],
+				name: items[cart_item].item_name,
+				rate: format_currency(items[cart_item].standard_rate, this.currency),
+				thumbnail: items[cart_item].thumbnail
+			};
+			this.cart.push(list_el);
 		}
 
 		frappe.run_serially([
@@ -344,37 +348,11 @@ class Payment {
 		});
 	}
 
-	init_vue() {
-		const me = this;
-		this.vue = new Vue({
-			el: '#payment-items',
-			data: {
-				currency: this.currency,
-				items: this.items,
-				cart: this.cart,
-			},
-			template: frappe.templates["modal"],
-			methods: {
-				formatCurrency(amount) {
-					return format_currency(amount, this.currency);
-				},
-				noItems() {
-					return $.isEmptyObject(this.items);
-				},
-				__(msg) {
-					/* Return translation of msg or msg, 
-					  if there is no translation */
-					return frappe._messages[msg] || msg;
-				}
-			}
-		});
-	}
-
 	set_item_overview() {
 		const html = frappe.render_template(frappe.templates["modal"], {
 			currency: this.currency,
-			items: this.items,
 			cart: this.cart,
+			no_items: frappe._("No items in cart.")
 		});
 		this.dialog.fields_dict.overview.$wrapper.html(html);
 	}

--- a/vue_simple_pos/vue_simple_pos/page/vue_simple_pos/vue_simple_pos.js
+++ b/vue_simple_pos/vue_simple_pos/page/vue_simple_pos/vue_simple_pos.js
@@ -288,7 +288,13 @@ class Payment {
 		this.mode_of_payment = __('Cash');
 		this.events = events;
 		this.cart = cart;
-		this.items = items;
+		this.items = {};
+
+		// Assign items and format price
+		for (var item in items) {
+			this.items[item] = items[item];
+			this.items[item].standard_rate = format_currency(items[item].standard_rate, this.currency);
+		}
 
 		frappe.run_serially([
 			this.make(),
@@ -299,10 +305,7 @@ class Payment {
 	}
 
 	open_modal() {
-		frappe.run_serially([
-			() => this.dialog.show(),
-			() => this.init_vue(),
-		]);
+		this.dialog.show();
 	}
 
 	make() {
@@ -368,7 +371,12 @@ class Payment {
 	}
 
 	set_item_overview() {
-		this.dialog.fields_dict.overview.$wrapper.html('<div id="payment-items"></div>');
+		const html = frappe.render_template(frappe.templates["modal"], {
+			currency: this.currency,
+			items: this.items,
+			cart: this.cart,
+		});
+		this.dialog.fields_dict.overview.$wrapper.html(html);
 	}
 
 	set_primary_action() {


### PR DESCRIPTION
- Replace Vue with `frappe.render_template(template, data_dict)`.
- Merged `items` dict and `cart` dict into list of cart items.